### PR TITLE
Rails is now a top-level config var in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,6 @@ AllCops:
     - 'bin/**/*'
     - 'Guardfile*'
 
-  # By default, the rails cops are not run. Override in project or home
-  # directory .rubocop.yml files, or by giving the -R/--rails option.
-  RunRailsCops: true
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
   # option.
@@ -61,6 +58,11 @@ AllCops:
 
 Metrics/LineLength:
   Max: 80
+
+# By default, the rails cops are not run. Override in project or home
+# directory .rubocop.yml files, or by giving the -R/--rails option.
+Rails:
+  Enabled: true
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
RunRailsCops: true under AllCops config object is deprecated

https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes-15